### PR TITLE
Redact environment in Command debug dumps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/shell/Command.java
+++ b/src/main/java/com/google/devtools/build/lib/shell/Command.java
@@ -359,8 +359,6 @@ public final class Command implements DescribableExecutionUnit {
       message.append(arg);
       message.append(']');
     }
-    message.append("; environment: ");
-    message.append(subprocessBuilder.getEnv());
     message.append("; working dir: ");
     File workingDirectory = subprocessBuilder.getWorkingDirectory();
     message.append(workingDirectory == null ?


### PR DESCRIPTION
Command objects contain the environment variables to pass to them, and their associated function to print a debug string prints out the environment.

This is not a problem in the common case, but apparently the docker strategy calls the debug printing functionality on error and leaks the environment to the console.