### PR TITLE
Add support for certs in the HTTP repository downloader

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -346,6 +346,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_collection",
         "//src/main/java/com/google/devtools/build/lib/analysis:view_creation_failed_exception",
         "//src/main/java/com/google/devtools/build/lib/analysis:workspace_status_action",
+        "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bugreport",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -186,6 +186,17 @@ public class AuthAndTLSOptions extends OptionsBase {
               + " the helper does not provide when the credentials expire.")
   public Duration credentialHelperCacheTimeout;
 
+  @Option(
+      name = "experimental_use_tls_in_http_downloader",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.CHANGES_INPUTS},
+      help =
+          "Whether to propagate TLS certificates and keys to the HTTP downloader. This is optional"
+              + " in case the new code to parse the (pre-existing) files doesn't work in this new"
+              + " context.")
+  public boolean useTlsInHttpDownloader;
+
   /** One of the values of the `--credential_helper` flag. */
   @AutoValue
   public abstract static class CredentialHelperOption {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -41,6 +41,8 @@ import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.WillClose;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 
 /**
  * Class for establishing connections to HTTP servers for downloading files.
@@ -70,6 +72,7 @@ class HttpConnector {
   private final float timeoutScaling;
   private final int maxAttempts;
   private final Duration maxRetryTimeout;
+  private final @Nullable SSLContext sslContext;
 
   HttpConnector(
       Locale locale,
@@ -78,7 +81,8 @@ class HttpConnector {
       Sleeper sleeper,
       float timeoutScaling,
       int maxAttempts,
-      Duration maxRetryTimeout) {
+      Duration maxRetryTimeout,
+      SSLContext sslContext) {
     this.locale = locale;
     this.eventHandler = eventHandler;
     this.proxyHelper = proxyHelper;
@@ -86,6 +90,7 @@ class HttpConnector {
     this.timeoutScaling = timeoutScaling;
     this.maxAttempts = maxAttempts > 0 ? maxAttempts : MAX_ATTEMPTS;
     this.maxRetryTimeout = maxRetryTimeout;
+    this.sslContext = sslContext;
   }
 
   HttpConnector(
@@ -94,7 +99,7 @@ class HttpConnector {
       ProxyHelper proxyHelper,
       Sleeper sleeper,
       float timeoutScaling) {
-    this(locale, eventHandler, proxyHelper, sleeper, timeoutScaling, 0, Duration.ZERO);
+    this(locale, eventHandler, proxyHelper, sleeper, timeoutScaling, 0, Duration.ZERO, null);
   }
 
   HttpConnector(
@@ -124,8 +129,17 @@ class HttpConnector {
     while (true) {
       HttpURLConnection connection = null;
       try {
-        connection = (HttpURLConnection)
-            url.openConnection(proxyHelper.createProxyIfNeeded(url));
+        if (HttpUtils.isProtocol(url, "https")) {
+          HttpsURLConnection httpsConnection = (HttpsURLConnection)
+              url.openConnection(proxyHelper.createProxyIfNeeded(url));
+          if (sslContext != null) {
+            httpsConnection.setSSLSocketFactory(sslContext.getSocketFactory());
+          }
+          connection = httpsConnection;
+        } else {
+          connection = (HttpURLConnection)
+              url.openConnection(proxyHelper.createProxyIfNeeded(url));
+        }
         // TODO(zecke): Revise once https://bugs.openjdk.java.net/browse/JDK-8163921 is fixed.
         connection.addRequestProperty("Accept", "text/html, image/gif, image/jpeg, */*");
         boolean isAlreadyCompressed =

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
+import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.buildeventstream.FetchEvent;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.clock.JavaClock;
@@ -40,6 +41,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Semaphore;
+import javax.net.ssl.SSLContext;
 
 /**
  * HTTP implementation of {@link Downloader}.
@@ -58,17 +60,20 @@ public class HttpDownloader implements Downloader {
   private final float timeoutScaling;
   private final int maxAttempts;
   private final Duration maxRetryTimeout;
+  private final AuthAndTLSOptions authAndTLSOptions;
 
   public HttpDownloader(
-      int maxAttempts, Duration maxRetryTimeout, int maxParallelDownloads, float timeoutScaling) {
+      int maxAttempts, Duration maxRetryTimeout, int maxParallelDownloads, float timeoutScaling,
+      AuthAndTLSOptions authAndTLSOptions) {
     this.maxAttempts = maxAttempts;
     this.maxRetryTimeout = maxRetryTimeout;
     semaphore = new Semaphore(maxParallelDownloads, true);
     this.timeoutScaling = timeoutScaling;
+    this.authAndTLSOptions = authAndTLSOptions;
   }
 
   public HttpDownloader() {
-    this(0, Duration.ZERO, 8, 1.0f);
+    this(0, Duration.ZERO, 8, 1.0f, new AuthAndTLSOptions());
   }
 
   @Override
@@ -171,8 +176,12 @@ public class HttpDownloader implements Downloader {
   }
 
   private HttpConnectorMultiplexer setUpConnectorMultiplexer(
-      ExtendedEventHandler eventHandler, Map<String, String> clientEnv) {
+      ExtendedEventHandler eventHandler, Map<String, String> clientEnv) throws IOException {
     ProxyHelper proxyHelper = new ProxyHelper(clientEnv);
+    SSLContext maybeSslContext = null;
+    if (authAndTLSOptions.useTlsInHttpDownloader) {
+      maybeSslContext = SSLContextBuilder.build(authAndTLSOptions);
+    }
     HttpConnector connector =
         new HttpConnector(
             LOCALE,
@@ -181,7 +190,8 @@ public class HttpDownloader implements Downloader {
             SLEEPER,
             timeoutScaling,
             maxAttempts,
-            maxRetryTimeout);
+            maxRetryTimeout,
+            maybeSslContext);
     ProgressInputStream.Factory progressInputStreamFactory =
         new ProgressInputStream.Factory(LOCALE, CLOCK, eventHandler);
     HttpStream.Factory httpStreamFactory = new HttpStream.Factory(progressInputStreamFactory);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/SSLContextBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/SSLContextBuilder.java
@@ -1,0 +1,166 @@
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+
+/** Helper methods to instantiate an {@link SSLContext}. */
+class SSLContextBuilder {
+
+  /**
+   * Instantiates an {@link SSLContext} from user-supplied configuration options.
+   *
+   * @param authAndTLSOptions the authentication options that specify where to find the certificates
+   *                          and keys to use
+   * @return the new {@link SSLContext} or null if there are no configured certificates or keys
+   * @throws IOException if there is any problem parsing the specified files
+   */
+  public static SSLContext build(AuthAndTLSOptions authAndTLSOptions) throws IOException {
+    String certPath = authAndTLSOptions.tlsClientCertificate;
+    String keyPath = authAndTLSOptions.tlsClientKey;
+
+    // Exit early if the user has provided no certificates.
+    if (certPath == null || keyPath == null) {
+      return null;
+    }
+
+    try {
+      Certificate[] certificates = parseCertificates(certPath);
+      PrivateKey privateKey = parsePrivateKey(keyPath);
+
+      KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keyStore.load(null, null);
+      keyStore.setKeyEntry("client", privateKey, new char[0], certificates);
+
+      KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(
+          KeyManagerFactory.getDefaultAlgorithm());
+      keyManagerFactory.init(keyStore, new char[0]);
+
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+
+      return sslContext;
+    } catch (IOException | CertificateException | NoSuchAlgorithmException | KeyStoreException
+             | UnrecoverableKeyException | KeyManagementException | InvalidKeySpecException e) {
+      throw new RuntimeException("Failed to build SSLContext", e);
+    }
+  }
+
+  /**
+   * Extracts and decodes multiple base64 chunks from a PKCS#12 file.
+   *
+   * @param path path to the file to parse
+   * @param marker string marker delimiting the various chunks in the file
+   * @return a collection of base64-decoded chunks
+   * @throws IOException if the content of the file is invalid
+   */
+  private static List<byte[]> parseChunks(String path, String marker)
+      throws IOException {
+    List<byte[]> chunks = new ArrayList<>();
+
+    String beginMarker = String.format("-----BEGIN %s-----", marker);
+    String endMarker = String.format("-----END %s-----", marker);
+
+    String content = Files.readString(Paths.get(path));
+    String[] lines = content.split("\\n");
+    StringBuilder base64 = null;
+    for (String line : lines) {
+      line = line.trim();
+
+      if (line.equals(beginMarker)) {
+        if (base64 != null) {
+          throw new IOException("Malformed file: nested BEGIN tags");
+        }
+
+        base64 = new StringBuilder();
+      } else if (line.equals(endMarker)) {
+        if (base64 == null) {
+          throw new IOException("Malformed file: END tag without BEGIN");
+        }
+
+        byte[] bytes = Base64.getDecoder().decode(base64.toString());
+        chunks.add(bytes);
+
+        base64 = null;
+      } else {
+        if (base64 == null) {
+          throw new IOException("Malformed file: content without BEGIN");
+        }
+
+        base64.append(line);
+      }
+    }
+
+    return chunks;
+  }
+
+  /**
+   * Extracts and decodes multiple certificates from a PKCS#12 file.
+   *
+   * @param certPath path to the file to parse
+   * @return a collection of certificates
+   * @throws IOException if the content of the file is invalid
+   */
+  private static Certificate[] parseCertificates(String certPath)
+      throws IOException, CertificateException {
+    List<byte[]> chunks = parseChunks(certPath, "CERTIFICATE");
+    Certificate[] certificates = new Certificate[chunks.size()];
+    int i = 0;
+    for (byte[] chunk : chunks) {
+      CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+      Certificate certificate = certFactory.generateCertificate(
+          new ByteArrayInputStream(chunk));
+      certificates[i++] = certificate;
+    }
+    return certificates;
+  }
+
+  /**
+   * Extracts and decodes a single private key from a PKCS#12 file.
+   *
+   * @param keyPath path to the file to parse
+   * @return a private key
+   * @throws IOException if the content of the file is invalid
+   */
+  private static PrivateKey parsePrivateKey(String keyPath)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    List<byte[]> chunks = parseChunks(keyPath, "PRIVATE KEY");
+    if (chunks.size() != 1) {
+      throw new IOException("Expected only one private key");
+    }
+    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(chunks.getFirst());
+
+    // Try different algorithms as we don't know the key type from PKCS#8 format alone.
+    String[] algorithms = {"RSA", "EC", "DSA"};
+    for (String algorithm : algorithms) {
+      try {
+        KeyFactory keyFactory = KeyFactory.getInstance(algorithm);
+        return keyFactory.generatePrivate(keySpec);
+      } catch (InvalidKeySpecException e) {
+        // Ignore; assume that the algorithm we tried was inappropriate.
+      }
+    }
+
+    throw new InvalidKeySpecException("Could not parse private key with any supported algorithm");
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.analysis.AnalysisOptions;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.BuildInfoEvent;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
+import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.bazel.repository.downloader.DelegatingDownloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions;
@@ -219,6 +220,10 @@ public class CommandEnvironment {
         Preconditions.checkNotNull(
             options.getOptions(CommonCommandOptions.class),
             "CommandEnvironment needs its options provider to have CommonCommandOptions loaded.");
+
+    AuthAndTLSOptions authAndTLSOptions =
+        Preconditions.checkNotNull(options.getOptions(AuthAndTLSOptions.class));
+
     Path workingDirectory;
     try {
       workingDirectory = computeWorkingDirectory(commandOptions);
@@ -277,7 +282,8 @@ public class CommandEnvironment {
             commandOptions.httpConnectorAttempts,
             commandOptions.httpConnectorRetryMaxTimeout,
             commandOptions.httpMaxParallelDownloads,
-            httpTimeoutScaling);
+            httpTimeoutScaling,
+            authAndTLSOptions);
     this.delegatingDownloader = new DelegatingDownloader(httpDownloader);
 
     ClientOptions clientOptions =

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
+import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.authandtls.StaticCredentials;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -77,7 +78,8 @@ public class HttpDownloaderTest {
 
   private final RepositoryCache repositoryCache = mock(RepositoryCache.class);
   // Scale timeouts down to make test fast.
-  private final HttpDownloader httpDownloader = new HttpDownloader(0, Duration.ZERO, 8, .1f);
+  private final HttpDownloader httpDownloader = new HttpDownloader(
+      0, Duration.ZERO, 8, .1f, new AuthAndTLSOptions());
   private final DownloadManager downloadManager =
       new DownloadManager(repositoryCache, httpDownloader, httpDownloader);
 


### PR DESCRIPTION
This modifies the HTTP repository downloader to respect the TLS certs and keys already provided to Bazel via AuthAndTLSOptions, and uses those to instantiate an SSLContext that the downloader can use.

Fixes #26733.